### PR TITLE
Implement blind signature request on election tap

### DIFF
--- a/lib/screens/elections_screen.dart
+++ b/lib/screens/elections_screen.dart
@@ -5,6 +5,7 @@ import '../providers/election_provider.dart';
 import '../widgets/election_card.dart';
 import 'election_detail_screen.dart';
 import '../generated/app_localizations.dart';
+import '../services/token_request_service.dart';
 
 class ElectionsScreen extends StatefulWidget {
   const ElectionsScreen({super.key});
@@ -43,7 +44,9 @@ class _ElectionsScreenState extends State<ElectionsScreen> {
                   ),
                   const SizedBox(height: 16),
                   Text(
-                    AppLocalizations.of(context).errorWithMessage(provider.error!),
+                    AppLocalizations.of(
+                      context,
+                    ).errorWithMessage(provider.error!),
                     style: Theme.of(context).textTheme.bodyLarge,
                     textAlign: TextAlign.center,
                   ),
@@ -67,22 +70,27 @@ class _ElectionsScreenState extends State<ElectionsScreen> {
                     Icon(
                       Icons.how_to_vote_outlined,
                       size: 80,
-                      color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.primary.withValues(alpha: 0.5),
                     ),
                     const SizedBox(height: 24),
                     Text(
                       AppLocalizations.of(context).noElectionsFound,
-                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: Theme.of(context).colorScheme.onSurface,
-                      ),
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
                     ),
                     const SizedBox(height: 12),
                     Text(
                       AppLocalizations.of(context).noActiveElectionsFound,
                       textAlign: TextAlign.center,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withValues(alpha: 0.7),
                       ),
                     ),
                   ],
@@ -108,6 +116,13 @@ class _ElectionsScreenState extends State<ElectionsScreen> {
   }
 
   void _navigateToElectionDetail(Election election) {
+    if (election.status.toLowerCase() == 'open') {
+      final service = TokenRequestService();
+      service.requestBlindSignature(election).catchError((e) {
+        debugPrint('Token request failed: $e');
+      });
+    }
+
     Navigator.push(
       context,
       MaterialPageRoute(

--- a/lib/services/token_request_service.dart
+++ b/lib/services/token_request_service.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+
+import '../config/app_config.dart';
+import '../models/election.dart';
+import '../models/voter.dart';
+import 'blind_signature_service.dart';
+import 'nostr_key_manager.dart';
+import 'nostr_service.dart';
+
+class TokenRequestService {
+  final NostrService _nostrService = NostrService();
+
+  Future<void> requestBlindSignature(Election election) async {
+    await _nostrService.connect(AppConfig.relayUrl);
+
+    final voter = Voter.generate();
+    final rsaKey = BlindSignatureService.publicKeyFromPem(election.rsaPubKey);
+    final result = BlindSignatureService.blindMessage(
+      voter.hashedNonce,
+      rsaKey,
+    );
+
+    final keys = await NostrKeyManager.getDerivedKeys();
+    final privHex = _bytesToHex(keys['privateKey']);
+    final pubHex = _bytesToHex(keys['publicKey']);
+
+    await _nostrService.sendBlindSignatureRequest(
+      ecPubKey: AppConfig.ecPublicKey,
+      electionId: election.id,
+      blindedNonce: result.blindedMessage,
+      voterPrivKeyHex: privHex,
+      voterPubKeyHex: pubHex,
+    );
+  }
+
+  String _bytesToHex(Uint8List bytes) {
+    return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
+}


### PR DESCRIPTION
## Summary
- add `TokenRequestService` to perform blind signature request
- enhance `NostrService` with login and blind request helpers
- trigger blind signature request when opening an open election

## Testing
- `dart format lib/services/token_request_service.dart lib/services/nostr_service.dart lib/screens/elections_screen.dart`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68503a2da1ac832db17c7652696b1ab4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for requesting a blind signature token when accessing election details for open elections.
  - Introduced a service to handle blind signature requests, improving the security and privacy of elections.
  - Enabled account login and sending of blind signature requests over the network.

- **Bug Fixes**
  - Improved connection checks before sending requests to ensure reliable operation.

- **Style**
  - Minor formatting improvements for better code readability (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->