### PR TITLE
feat: Change app identifier to vote.criptocracia.app

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.criptocracia.criptocracia"
+    namespace = "vote.criptocracia.app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.criptocracia.criptocracia"
+        applicationId = "vote.criptocracia.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/kotlin/vote/criptocracia/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/vote/criptocracia/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.criptocracia.criptocracia
+package vote.criptocracia.app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "criptocracia")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.criptocracia.criptocracia")
+set(APPLICATION_ID "vote.criptocracia.app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/criptocracia.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/criptocracia";
@@ -399,7 +399,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/criptocracia.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/criptocracia";
@@ -413,7 +413,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/criptocracia.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/criptocracia";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = criptocracia
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.criptocracia.criptocracia
+PRODUCT_BUNDLE_IDENTIFIER = vote.criptocracia.app
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2025 com.criptocracia. All rights reserved.


### PR DESCRIPTION
This commit updates the app identifier across all platforms from com.criptocracia.criptocracia to vote.criptocracia.app for improved branding consistency and domain-based identification.

## Changes Made:

### Android Platform
- Update namespace and applicationId in build.gradle.kts
- Move MainActivity.kt to new package structure (vote.criptocracia.app)
- Update package declaration in MainActivity.kt

### iOS Platform
- Update PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj for main app
- Update PRODUCT_BUNDLE_IDENTIFIER for RunnerTests target
- All build configurations (Debug, Release, Profile) updated

### macOS Platform
- Update PRODUCT_BUNDLE_IDENTIFIER in AppInfo.xcconfig

## Verification
- ✅ Android APK builds successfully with new identifier
- ✅ Linux desktop build works correctly
- ✅ Web build compiles without issues
- ✅ Flutter analyze passes with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application ID and namespace for Android, iOS, macOS, and Linux platforms to "vote.criptocracia.app".
  * Adjusted package declarations and bundle identifiers to reflect the new app identity across all platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->